### PR TITLE
Deliver vechain.energy Milestone 4 + 5

### DIFF
--- a/milestone-delivery/deliveries/vechain.energy-M4.md
+++ b/milestone-delivery/deliveries/vechain.energy-M4.md
@@ -1,0 +1,17 @@
+# Milestone Delivery :mailbox:
+
+**The Ethereum address has been filled out correctly for this milestone and the delivery is according to the official [milestone delivery guidelines](../).**  
+
+* **PR Link:** https://github.com/vechain/grant-program/pull/46 
+* **Milestone Number:** 4
+
+The functionality defined for the milestone was completed. The website is available on TestNet and MainNet.
+
+| Number | Deliverable | Link | Notes |
+|-|-|-|-|
+| 4.1 | TestNet-Sponsorship | https://testnet.vechain.energy | ![](https://s3.eu-central-1.amazonaws.com/share.energy/M4.1.jpg) + https://testnet.vechain.energy/#/docs/what-is-fee-delegation
+| 4.2 | MainNet-Sponsorship |  https://mainnet.vechain.energy | ![](https://s3.eu-central-1.amazonaws.com/share.energy/M4.2.jpg) + https://vechain.energy/#/docs/what-is-fee-delegation
+| 4.3 | Setup Socials | https://twitter.com/VeChainEnergy + https://discord.gg/dhVCVNbHRT + https://medium.com/vechain-energy | 
+| 4.4 | Publication | https://mainnet.vechain.energy + https://vechain.energy
+| 4.5 | Maintenance | | this is an upfront cost
+

--- a/milestone-delivery/deliveries/vechain.energy-M5.md
+++ b/milestone-delivery/deliveries/vechain.energy-M5.md
@@ -1,0 +1,17 @@
+# Milestone Delivery :mailbox:
+
+**The Ethereum address has been filled out correctly for this milestone and the delivery is according to the official [milestone delivery guidelines](../).**  
+
+* **PR Link:** https://github.com/vechain/grant-program/pull/46 
+* **Milestone Number:** 5
+
+There is no specific deliverable. This milestone will be converted into:
+
+1. pay server costs for 12 months (ca. $1,440), monthly circa based on:
+1. purchase VTHO from the market to sponsor transactions on the MainNet (Community-Projects)
+
+The VTHO will be purchased once the payment is disbursed.
+
+The address used for purchase will be:
+
+* https://explore.vechain.org/accounts/0x82e66a2ab5015080c40a348c1c39f3e7922d331d


### PR DESCRIPTION
## Milestone 4

The  fourth Milestone is completed. It was setup and started a progress of content-creation.

Deliverables were agreed to be proven by links to Test- and MainNet-installations.

* TestNet: https://testnet.vechain.energy
* MainNet: https://vechain.energy


## Milestone 5

The fifth Milestone has no deliverable. The costs will be used to cover a Sponsorship-Pool for other projects/developers and hosting costs.


Thank you again for your support! I am very grateful for your support and hope everything is as expected.


---

Not required for the deliveries but still I like to share a dashboard screenshot with active data:

<img src="https://s3.eu-central-1.amazonaws.com/share.energy/example-grant-m3-m4.jpg" />